### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "resend": "^6.9.2",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "jest": "^30.2.0",


### PR DESCRIPTION
Potential fix for [https://github.com/5cisummai/freeappractice/security/code-scanning/6](https://github.com/5cisummai/freeappractice/security/code-scanning/6)

To fix the issue, we should introduce rate limiting middleware on the sensitive, anonymous endpoints that touch the database and/or perform expensive operations, in particular `/forgot-password` and `/reset-password`. The standard way in an Express app is to use a middleware like `express-rate-limit`, configure a reasonably strict limit for these endpoints, and apply it to their route definitions. This preserves existing functionality while adding protection against brute-force and DoS attacks.

Concretely, in `routes/api/auth.js`:

1. Add an import (require) for `express-rate-limit` near the top of the file, alongside the other `require` calls.
2. Define one or more rate limiter instances. For example:
   - A `passwordResetLimiter` that allows only a small number of attempts per IP per time window for `/forgot-password` and `/reset-password` (e.g., 5 requests per 15 minutes).
3. Apply this limiter as middleware to the `router.post('/forgot-password', ...)` and `router.post('/reset-password', ...)` routes by inserting it as a second argument before the async handler. This does not alter the handler logic; it just wraps it with rate limiting.

No other functionality of the handlers needs to change; we’re only adding middleware and configuration constants inside this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
