### PR TITLE
Potential fix for code scanning alert no. 24: Database query built from user-controlled sources

### DIFF
--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -87,11 +87,11 @@ router.get('/verify-email', async (req, res) => {
     try {
         const { token } = req.query;
 
-        if (!token) {
+        if (!token || typeof token !== 'string') {
             return res.status(400).json({ error: 'Verification token is required' });
         }
 
-        const user = await User.findOne({ emailToken: token, emailTokenExpires: { $gt: Date.now() } });
+        const user = await User.findOne({ emailToken: { $eq: token }, emailTokenExpires: { $gt: Date.now() } });
 
         if (!user) {
             return res.status(400).json({ error: 'Invalid or expired verification token' });


### PR DESCRIPTION
Potential fix for [https://github.com/5cisummai/freeappractice/security/code-scanning/24](https://github.com/5cisummai/freeappractice/security/code-scanning/24)

In general, to fix this type of problem in MongoDB/Mongoose queries, either (a) ensure that user-controlled values are treated as literal values by wrapping them in an operator like `$eq`, or (b) validate and restrict them to benign primitive types (for example, check they are strings) before constructing the query object. Both approaches prevent user input from being interpreted as a query object containing operators such as `$gt`, `$ne`, or `$where`.

The best fix here without changing observable behavior is to validate that `token` is a string and then use it in the query in a way that ensures it is treated as a literal. We can first add a type check after extracting `token` from `req.query`, returning a 400 response if it is not a string. Then, we can make the query slightly more explicit by wrapping the value with `$eq`, i.e., `emailToken: { $eq: token }`. This matches the mitigation pattern from the background section and guarantees the field comparison is a simple equality with the provided token, rather than potentially interpreting an object as an operator-bearing query. All these changes are confined to the `/verify-email` route in `routes/api/auth.js`, around lines 86–95; no new imports are required, as we only use standard JavaScript checks and Mongoose’s existing query syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
