### PR TITLE
Release 1.4.8: fix live question generation schema 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "freeappractice-svelte",
 	"private": true,
-	"version": "1.4.7",
+	"version": "1.4.8",
 	"packageManager": "bun@1.3.14",
 	"type": "module",
 	"scripts": {

--- a/src/lib/ai/openai-structured-schema.ts
+++ b/src/lib/ai/openai-structured-schema.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+
+type JsonSchemaNode = {
+	type?: string | string[];
+	properties?: Record<string, JsonSchemaNode>;
+	required?: string[];
+	items?: JsonSchemaNode | JsonSchemaNode[];
+	anyOf?: JsonSchemaNode[];
+	oneOf?: JsonSchemaNode[];
+	allOf?: JsonSchemaNode[];
+	$defs?: Record<string, JsonSchemaNode>;
+	definitions?: Record<string, JsonSchemaNode>;
+};
+
+function isObjectSchema(node: JsonSchemaNode): boolean {
+	const t = node.type;
+	if (t === 'object') return true;
+	if (Array.isArray(t) && t.includes('object')) return true;
+	return Boolean(node.properties);
+}
+
+/**
+ * OpenAI structured outputs require every key in `properties` to also appear in
+ * `required`. Zod `.optional()` fields violate that and fail before generation.
+ */
+export function findOpenAiOptionalPropertyPaths(
+	schema: z.ZodType,
+	opts?: { schemaName?: string }
+): string[] {
+	const jsonSchema = z.toJSONSchema(schema) as JsonSchemaNode;
+	const issues: string[] = [];
+	const rootLabel = opts?.schemaName ?? 'schema';
+
+	function visit(node: JsonSchemaNode, path: string): void {
+		if (isObjectSchema(node) && node.properties) {
+			const required = new Set(node.required ?? []);
+			for (const key of Object.keys(node.properties)) {
+				const childPath = path ? `${path}.${key}` : key;
+				if (!required.has(key)) {
+					issues.push(childPath);
+				}
+				visit(node.properties[key]!, childPath);
+			}
+		}
+
+		if (node.items) {
+			const items = Array.isArray(node.items) ? node.items : [node.items];
+			for (const [i, item] of items.entries()) {
+				visit(item, `${path}[${i}]`);
+			}
+		}
+
+		for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+			const variants = node[key];
+			if (!variants) continue;
+			for (const [i, variant] of variants.entries()) {
+				visit(variant, `${path}/${key}[${i}]`);
+			}
+		}
+
+		for (const defsKey of ['$defs', 'definitions'] as const) {
+			const defs = node[defsKey];
+			if (!defs) continue;
+			for (const [name, def] of Object.entries(defs)) {
+				visit(def, `${path}/${defsKey}/${name}`);
+			}
+		}
+	}
+
+	visit(jsonSchema, rootLabel);
+	// Paths are rooted at schema name for clarity; strip the root label prefix for
+	// property paths that are relative to the object itself when rootLabel === 'schema'.
+	return issues.map((p) => (p.startsWith(`${rootLabel}.`) ? p.slice(rootLabel.length + 1) : p));
+}
+
+export function assertOpenAiCompatibleObjectSchema(
+	schema: z.ZodType,
+	opts?: { schemaName?: string }
+): void {
+	const missing = findOpenAiOptionalPropertyPaths(schema, opts);
+	if (missing.length === 0) return;
+
+	const label = opts?.schemaName ? `'${opts.schemaName}'` : 'structured output schema';
+	throw new Error(
+		`OpenAI ${label} is invalid: properties missing from required: ${missing.join(', ')}. ` +
+			`Use required fields or .nullable() instead of .optional().`
+	);
+}

--- a/src/lib/ai/service.server.ts
+++ b/src/lib/ai/service.server.ts
@@ -3,6 +3,7 @@ import { generateText, streamText, Output, NoObjectGeneratedError } from 'ai';
 import type { z } from 'zod';
 import { OPEN_AI_KEY } from '$env/static/private';
 import { env } from '$env/dynamic/private';
+import { assertOpenAiCompatibleObjectSchema } from '$lib/ai/openai-structured-schema';
 import { logger } from '$lib/server/logger';
 
 const OPENAI_BASE_URL = env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
@@ -97,6 +98,7 @@ export async function runStructuredCompletion<T>(
 ): Promise<{ parsed: T; model: string }> {
 	const doneAiCall = logger.aiCall(callName, opts.model, logContext);
 	const { system, messages } = splitSystemMessages(opts.messages);
+	assertOpenAiCompatibleObjectSchema(opts.schema, { schemaName: opts.schemaName ?? callName });
 	try {
 		const result = await generateText({
 			model: model(opts.model),

--- a/src/lib/ai/service.server.ts
+++ b/src/lib/ai/service.server.ts
@@ -3,7 +3,6 @@ import { generateText, streamText, Output, NoObjectGeneratedError } from 'ai';
 import type { z } from 'zod';
 import { OPEN_AI_KEY } from '$env/static/private';
 import { env } from '$env/dynamic/private';
-import { assertOpenAiCompatibleObjectSchema } from '$lib/ai/openai-structured-schema';
 import { logger } from '$lib/server/logger';
 
 const OPENAI_BASE_URL = env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1';
@@ -98,7 +97,6 @@ export async function runStructuredCompletion<T>(
 ): Promise<{ parsed: T; model: string }> {
 	const doneAiCall = logger.aiCall(callName, opts.model, logContext);
 	const { system, messages } = splitSystemMessages(opts.messages);
-	assertOpenAiCompatibleObjectSchema(opts.schema, { schemaName: opts.schemaName ?? callName });
 	try {
 		const result = await generateText({
 			model: model(opts.model),

--- a/src/lib/components/questions/question-card.svelte
+++ b/src/lib/components/questions/question-card.svelte
@@ -113,6 +113,7 @@
 	let mounted = $state(!browser);
 	let questionCount = $state(0);
 	let statusMessage = $state('');
+	let questionLoadFailed = $state(false);
 	let currentQuestion = $state<GeneratedQuestion | null>(null);
 	let seenQuestionIds = $state<string[]>([]);
 	let bugReportOpen = $state(false);
@@ -191,6 +192,7 @@
 	const showEmptyState = $derived(
 		mounted && !isLoading && requestVersion === 0 && !currentQuestion
 	);
+	const showErrorState = $derived(mounted && !isLoading && questionLoadFailed);
 
 	async function requestQuestion(
 		className: string,
@@ -383,6 +385,7 @@
 		}
 
 		isLoading = true;
+		questionLoadFailed = false;
 
 		if (reason === 'skip') statusMessage = 'Skipped current question.';
 		else if (reason === 'not-learned') statusMessage = "Marked as: I haven't learned this yet.";
@@ -414,6 +417,8 @@
 				status: error instanceof QuestionRequestError ? error.status : null,
 				latencyMs: Date.now() - loadStartedAt
 			});
+			questionLoadFailed = true;
+			currentQuestion = null;
 			statusMessage = error instanceof Error ? error.message : 'Could not load question.';
 		} finally {
 			isLoading = false;
@@ -697,6 +702,20 @@
 			<p class="max-w-sm text-sm text-muted-foreground/80">
 				Select a class and unit above, then generate a question to start practicing.
 			</p>
+		</Card.Content>
+	</Card.Root>
+{:else if showErrorState}
+	<Card.Root class={cn('relative overflow-visible bg-transparent shadow-none ring-0', className)}>
+		<Card.Content
+			class="relative flex min-h-40 flex-col items-center justify-center gap-3 px-6 pb-12 text-center"
+		>
+			<p class="text-lg font-medium text-muted-foreground sm:text-xl">
+				We couldn’t load this question
+			</p>
+			<p class="max-w-sm text-sm text-muted-foreground/80">
+				Sorry about that — we’ve noted this so we can get it fixed. Please try again in a moment.
+			</p>
+			<Button onclick={() => void loadQuestion()} disabled={isLoading}>Try again</Button>
 		</Card.Content>
 	</Card.Root>
 {:else}

--- a/src/lib/questions/generation.server.ts
+++ b/src/lib/questions/generation.server.ts
@@ -137,7 +137,8 @@ function buildDiversitySection(
 
 // ── Zod schemas ────────────────────────────────────────────────
 
-const APQuestion = z.object({
+/** Exported for OpenAI structured-output required-field regression tests. */
+export const apQuestionSchema = z.object({
 	question: z
 		.string()
 		.describe(
@@ -151,15 +152,15 @@ const APQuestion = z.object({
 	explanation: z
 		.string()
 		.describe('Detailed explanation of the correct answer and why distractors are wrong'),
+	// Must be required (not .optional): OpenAI structured outputs require every
+	// property key to appear in JSON Schema `required`.
 	hint1: z
 		.string()
-		.optional()
 		.describe(
 			'Brief progressive hint after a first incorrect answer; do not reveal the correct letter'
 		),
 	hint2: z
 		.string()
-		.optional()
 		.describe(
 			'Stronger progressive hint after a second incorrect answer; still do not reveal the correct letter'
 		),
@@ -169,6 +170,8 @@ const APQuestion = z.object({
 			'1-2 sentence description of the specific concept, subtopic, or scenario this question tests (used for diversity tracking — be precise and distinct)'
 		)
 });
+
+const APQuestion = apQuestionSchema;
 
 type APQuestionData = z.infer<typeof APQuestion>;
 

--- a/src/lib/questions/generation.server.ts
+++ b/src/lib/questions/generation.server.ts
@@ -9,6 +9,7 @@ import {
 	ADVANCED_MODEL,
 	LATEX_RULE
 } from '$lib/ai/service.server';
+import { assertOpenAiCompatibleObjectSchema } from '$lib/ai/openai-structured-schema';
 import { QuestionGenerationError } from '$lib/questions/question-errors.server';
 
 /**
@@ -171,9 +172,9 @@ export const apQuestionSchema = z.object({
 		)
 });
 
-const APQuestion = apQuestionSchema;
+assertOpenAiCompatibleObjectSchema(apQuestionSchema, { schemaName: 'ap_question' });
 
-type APQuestionData = z.infer<typeof APQuestion>;
+type APQuestionData = z.infer<typeof apQuestionSchema>;
 
 export type { APQuestionData };
 
@@ -356,7 +357,7 @@ OUTPUT:
 				{ role: 'system', content: systemPrompt },
 				{ role: 'user', content: userMessage }
 			],
-			schema: APQuestion,
+			schema: apQuestionSchema,
 			schemaName: 'ap_question',
 			reasoningEffort: model === ADVANCED_MODEL ? 'medium' : undefined
 		},

--- a/src/routes/(app)/app/settings/+page.svelte
+++ b/src/routes/(app)/app/settings/+page.svelte
@@ -313,7 +313,7 @@
 						<p class="text-sm font-medium text-foreground">App version</p>
 						<p class="text-sm text-muted-foreground">Current Free AP Practice release.</p>
 					</div>
-					<p class="text-sm font-medium text-foreground tabular-nums">1.4.7</p>
+					<p class="text-sm font-medium text-foreground tabular-nums">1.4.8</p>
 				</div>
 				<div class="flex items-center justify-between gap-4 border-t border-border/60 px-4 py-3.5">
 					<div class="min-w-0 space-y-0.5">

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -20,7 +20,7 @@
 				{
 					title: 'Improvements',
 					items: [
-						'Structured AI schemas are validated before model calls so incompatible optional fields fail fast in development and tests',
+						'Structured AI schemas for question generation are checked at module load so incompatible optional fields fail fast in tests and startup',
 						'Added unit and mocked pipeline coverage for MCQ generation schema compatibility and persistence'
 					]
 				}

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -7,6 +7,25 @@
 
 	const changelog = [
 		{
+			version: '1.4.8',
+			date: 'July 18, 2026',
+			sections: [
+				{
+					title: 'Fixes',
+					items: [
+						'Fixed live question generation failing with a 500 when the OpenAI structured-output schema treated progressive hints as optional'
+					]
+				},
+				{
+					title: 'Improvements',
+					items: [
+						'Structured AI schemas are validated before model calls so incompatible optional fields fail fast in development and tests',
+						'Added unit and mocked pipeline coverage for MCQ generation schema compatibility and persistence'
+					]
+				}
+			]
+		},
+		{
 			version: '1.4.7',
 			date: 'July 16, 2026',
 			sections: [

--- a/src/routes/changelog/+page.svelte
+++ b/src/routes/changelog/+page.svelte
@@ -13,7 +13,8 @@
 				{
 					title: 'Fixes',
 					items: [
-						'Fixed live question generation failing with a 500 when the OpenAI structured-output schema treated progressive hints as optional'
+						'Fixed live question generation failing with a 500 when the OpenAI structured-output schema treated progressive hints as optional',
+						'Question card now shows a clear retryable error state instead of a blank panel when generation fails'
 					]
 				},
 				{

--- a/tests/unit/ai/openai-structured-schema.test.ts
+++ b/tests/unit/ai/openai-structured-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+	assertOpenAiCompatibleObjectSchema,
+	findOpenAiOptionalPropertyPaths
+} from '$lib/ai/openai-structured-schema';
+
+describe('openai structured schema compatibility', () => {
+	it('flags Zod .optional() fields that OpenAI rejects', () => {
+		const schema = z.object({
+			question: z.string(),
+			hint1: z.string().optional(),
+			hint2: z.string().optional()
+		});
+
+		expect(findOpenAiOptionalPropertyPaths(schema)).toEqual(
+			expect.arrayContaining(['hint1', 'hint2'])
+		);
+		expect(() => assertOpenAiCompatibleObjectSchema(schema, { schemaName: 'ap_question' })).toThrow(
+			/Missing 'hint1'|hint1|required/i
+		);
+	});
+
+	it('accepts required and nullable fields', () => {
+		const schema = z.object({
+			question: z.string(),
+			hint1: z.string(),
+			hint2: z.string().nullable()
+		});
+
+		expect(findOpenAiOptionalPropertyPaths(schema)).toEqual([]);
+		expect(() => assertOpenAiCompatibleObjectSchema(schema)).not.toThrow();
+	});
+
+	it('flags nested optional properties', () => {
+		const schema = z.object({
+			outer: z.object({
+				innerOptional: z.string().optional()
+			})
+		});
+
+		expect(findOpenAiOptionalPropertyPaths(schema)).toEqual(
+			expect.arrayContaining(['outer.innerOptional'])
+		);
+	});
+});

--- a/tests/unit/questions/ap-question-schema.test.ts
+++ b/tests/unit/questions/ap-question-schema.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assertOpenAiCompatibleObjectSchema,
+	findOpenAiOptionalPropertyPaths
+} from '$lib/ai/openai-structured-schema';
+import { apQuestionSchema } from '$lib/questions/generation.server';
+
+describe('apQuestionSchema OpenAI structured-output compatibility', () => {
+	it('includes every property in JSON Schema required (OpenAI rejects .optional())', () => {
+		expect(findOpenAiOptionalPropertyPaths(apQuestionSchema)).toEqual([]);
+		expect(() =>
+			assertOpenAiCompatibleObjectSchema(apQuestionSchema, { schemaName: 'ap_question' })
+		).not.toThrow();
+	});
+
+	it('requires hint1 and hint2 so multi-attempt live generation cannot 500 on schema', () => {
+		const missing = findOpenAiOptionalPropertyPaths(apQuestionSchema);
+		expect(missing).not.toEqual(expect.arrayContaining(['hint1', 'hint2']));
+		expect(() =>
+			assertOpenAiCompatibleObjectSchema(apQuestionSchema, { schemaName: 'ap_question' })
+		).not.toThrow();
+	});
+});

--- a/tests/unit/questions/ap-question-schema.test.ts
+++ b/tests/unit/questions/ap-question-schema.test.ts
@@ -6,16 +6,8 @@ import {
 import { apQuestionSchema } from '$lib/questions/generation.server';
 
 describe('apQuestionSchema OpenAI structured-output compatibility', () => {
-	it('includes every property in JSON Schema required (OpenAI rejects .optional())', () => {
+	it('keeps every property required so OpenAI does not reject hint1/hint2 as optional', () => {
 		expect(findOpenAiOptionalPropertyPaths(apQuestionSchema)).toEqual([]);
-		expect(() =>
-			assertOpenAiCompatibleObjectSchema(apQuestionSchema, { schemaName: 'ap_question' })
-		).not.toThrow();
-	});
-
-	it('requires hint1 and hint2 so multi-attempt live generation cannot 500 on schema', () => {
-		const missing = findOpenAiOptionalPropertyPaths(apQuestionSchema);
-		expect(missing).not.toEqual(expect.arrayContaining(['hint1', 'hint2']));
 		expect(() =>
 			assertOpenAiCompatibleObjectSchema(apQuestionSchema, { schemaName: 'ap_question' })
 		).not.toThrow();

--- a/tests/unit/questions/generate-ap-question.pipeline.test.ts
+++ b/tests/unit/questions/generate-ap-question.pipeline.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+vi.mock('$env/static/private', () => ({
+	OPEN_AI_KEY: 'test-key'
+}));
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		ADVANCED_MODEL: 'test-advanced-model',
+		BASIC_MODEL: 'test-basic-model',
+		TUTOR_MODEL: 'test-tutor-model'
+	}
+}));
+
+const generateTextMock = vi.fn();
+
+vi.mock('ai', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('ai')>();
+	return {
+		...actual,
+		generateText: (...args: unknown[]) => generateTextMock(...args)
+	};
+});
+
+const saveQuestionToS3 = vi.fn(async () => 'persisted-question-id');
+vi.mock('$lib/questions/storage.server', () => ({
+	saveQuestionToS3: (...args: unknown[]) => saveQuestionToS3(...args)
+}));
+
+const recordMcqGenerated = vi.fn(async () => {});
+vi.mock('$lib/questions/gen-stats.server', () => ({
+	recordMcqGenerated: (...args: unknown[]) => recordMcqGenerated(...args)
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		aiCall: () => () => {},
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn()
+	}
+}));
+
+import { runStructuredCompletion } from '$lib/ai/service.server';
+import { generateAPQuestion } from '$lib/questions/generation.server';
+
+const validGeneratedQuestion = {
+	question: 'Which agricultural practice is most associated with intensive subsistence farming?',
+	optionA: 'Nomadic herding across arid steppes',
+	optionB: 'Wet-rice cultivation on small plots',
+	optionC: 'Ranching on extensive grasslands',
+	optionD: 'Plantation monoculture for export',
+	correctAnswer: 'B' as const,
+	explanation: 'Intensive subsistence farming often centers on wet-rice cultivation.',
+	hint1: 'Think about high labor input on small parcels of land.',
+	hint2: 'Consider East and South Asian rice paddies rather than cattle ranching.',
+	topicsCovered: 'Intensive subsistence agriculture and wet-rice farming patterns'
+};
+
+describe('MCQ live generation pipeline', () => {
+	beforeEach(() => {
+		generateTextMock.mockReset();
+		saveQuestionToS3.mockClear();
+		recordMcqGenerated.mockClear();
+	});
+
+	it('rejects OpenAI-incompatible schemas before calling the model (prod hint1 failure)', async () => {
+		const badSchema = z.object({
+			question: z.string(),
+			hint1: z.string().optional()
+		});
+
+		await expect(
+			runStructuredCompletion(
+				'generateAPQuestion',
+				{
+					model: 'test-advanced-model',
+					messages: [{ role: 'user', content: 'x' }],
+					schema: badSchema,
+					schemaName: 'ap_question'
+				},
+				{ className: 'AP Human Geography' }
+			)
+		).rejects.toThrow(/hint1|required|optional/i);
+
+		expect(generateTextMock).not.toHaveBeenCalled();
+	});
+
+	it('runs generateAPQuestion end-to-end: schema-safe AI output → S3 persist → result', async () => {
+		generateTextMock.mockResolvedValue({
+			output: validGeneratedQuestion,
+			usage: { inputTokens: 10, outputTokens: 20 }
+		});
+
+		const result = await generateAPQuestion({
+			className: 'AP Human Geography',
+			unit: 'Unit 5: Agriculture and Rural Land-Use Patterns and Processes'
+		});
+
+		expect(generateTextMock).toHaveBeenCalledTimes(1);
+		expect(saveQuestionToS3).toHaveBeenCalledTimes(1);
+		expect(saveQuestionToS3).toHaveBeenCalledWith(
+			expect.objectContaining({
+				question: validGeneratedQuestion.question,
+				hint1: validGeneratedQuestion.hint1,
+				hint2: validGeneratedQuestion.hint2,
+				apClass: 'AP Human Geography',
+				unit: 'Unit 5: Agriculture and Rural Land-Use Patterns and Processes'
+			})
+		);
+		expect(result.questionId).toBe('persisted-question-id');
+		expect(result.answer.hint1).toBe(validGeneratedQuestion.hint1);
+		expect(result.answer.hint2).toBe(validGeneratedQuestion.hint2);
+		expect(result.provider).toBe('openai');
+		expect(result.model).toBe('test-basic-model'); // Human Geography → basic
+		expect(result.timing?.generationMs).toBeGreaterThanOrEqual(0);
+		expect(result.timing?.persistenceMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it('surfaces persistence failures as QuestionGenerationError after a successful model response', async () => {
+		generateTextMock.mockResolvedValue({
+			output: validGeneratedQuestion,
+			usage: { inputTokens: 1, outputTokens: 1 }
+		});
+		saveQuestionToS3.mockRejectedValueOnce(new Error('S3 unavailable'));
+
+		await expect(
+			generateAPQuestion({
+				className: 'AP Biology',
+				unit: 'Unit 1'
+			})
+		).rejects.toMatchObject({
+			name: 'QuestionGenerationError',
+			message: 'Failed to persist generated question'
+		});
+	});
+});

--- a/tests/unit/questions/generate-ap-question.pipeline.test.ts
+++ b/tests/unit/questions/generate-ap-question.pipeline.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { z } from 'zod';
 
 vi.mock('$env/static/private', () => ({
 	OPEN_AI_KEY: 'test-key'
@@ -42,7 +41,6 @@ vi.mock('$lib/server/logger', () => ({
 	}
 }));
 
-import { runStructuredCompletion } from '$lib/ai/service.server';
 import { generateAPQuestion } from '$lib/questions/generation.server';
 
 const validGeneratedQuestion = {
@@ -63,28 +61,6 @@ describe('MCQ live generation pipeline', () => {
 		generateTextMock.mockReset();
 		saveQuestionToS3.mockClear();
 		recordMcqGenerated.mockClear();
-	});
-
-	it('rejects OpenAI-incompatible schemas before calling the model (prod hint1 failure)', async () => {
-		const badSchema = z.object({
-			question: z.string(),
-			hint1: z.string().optional()
-		});
-
-		await expect(
-			runStructuredCompletion(
-				'generateAPQuestion',
-				{
-					model: 'test-advanced-model',
-					messages: [{ role: 'user', content: 'x' }],
-					schema: badSchema,
-					schemaName: 'ap_question'
-				},
-				{ className: 'AP Human Geography' }
-			)
-		).rejects.toThrow(/hint1|required|optional/i);
-
-		expect(generateTextMock).not.toHaveBeenCalled();
 	});
 
 	it('runs generateAPQuestion end-to-end: schema-safe AI output → S3 persist → result', async () => {


### PR DESCRIPTION
## Summary
- Fix live `/api/question` 500s caused by OpenAI rejecting optional `hint1`/`hint2` in the structured-output schema
- Validate `apQuestionSchema` at module load (not on every AI call) and add unit/pipeline coverage
- Show a polite retryable error state on the question card when generation fails

## Test plan
- [ ] Unit tests: `bun run test:unit` (schema + generate pipeline)
- [ ] Trigger a cache-miss generate in prod-like env; confirm 200 and hints present
- [ ] Force `/api/question` failure (e.g. bad key locally) and confirm error panel + Try again works
- [ ] Confirm cached question path still works (no blank card)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer error feedback when a question cannot be loaded, including a “Try again” option.
  * Improved compatibility for generated questions with structured AI responses.

* **Bug Fixes**
  * Fixed question-generation handling to prevent structured response validation issues.
  * Improved error reporting when saving generated questions fails.

* **Documentation**
  * Added release notes for version 1.4.8.
  * Updated the displayed application version to 1.4.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->