### PR TITLE
Release 1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "freeappractice-svelte",
 	"private": true,
-	"version": "1.6.9",
+	"version": "1.7.4",
 	"packageManager": "bun@1.3.14",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"db:generate": "drizzle-kit generate --config=drizzle.config.ts",
 		"db:apply": "bun scripts/apply-neon-migrations.ts",
 		"auth:cleanup-unverified": "bun scripts/cleanup-unverified-users.ts",
-		"auth:trim-user-names": "bun scripts/trim-user-names.ts",
+		"auth:trim-user-names": "bun --preload ./scripts/bun-sveltekit-env-preload.ts scripts/trim-user-names.ts",
 		"auth:backfill-personal-orgs": "bun --preload ./scripts/bun-sveltekit-env-preload.ts scripts/backfill-personal-organizations.ts",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/src/lib/components/marketing/landing-hero.svelte
+++ b/src/lib/components/marketing/landing-hero.svelte
@@ -5,9 +5,24 @@
 
 	let { children }: { children?: Snippet } = $props();
 	let isDark = $state(false);
+	let webglSupported = $state<boolean | null>(null);
+
+	function supportsWebGL2(): boolean {
+		try {
+			const canvas = document.createElement('canvas');
+			const context = canvas.getContext('webgl2');
+			if (!context) return false;
+
+			context.getExtension('WEBGL_lose_context')?.loseContext();
+			return true;
+		} catch {
+			return false;
+		}
+	}
 
 	onMount(() => {
 		const root = document.documentElement;
+		webglSupported = supportsWebGL2();
 		const syncTheme = () => {
 			isDark = root.classList.contains('dark');
 		};
@@ -27,30 +42,34 @@
 	class="relative isolate z-0 -mt-14 flex min-h-svh flex-col items-center overflow-hidden bg-background px-5 pt-32 pb-20 sm:px-8 sm:pt-40 sm:pb-28 lg:px-10 lg:pt-44 lg:pb-32"
 >
 	<div class="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
-		<HalftoneCMYK
-			width="100%"
-			height="100%"
-			image={heroImage}
-			class="size-full"
-			colorBack={isDark ? '#080b14' : '#fbfaf4'}
-			colorC="#2563eb"
-			colorM="#8b5cf6"
-			colorY="#f4b740"
-			colorK="#1e3a8a"
-			type="ink"
-			size={0.12}
-			gridNoise={0.08}
-			softness={0.65}
-			contrast={1.05}
-			gainC={0.18}
-			gainM={0.08}
-			gainY={0.1}
-			gainK={0.04}
-			grainMixer={0.02}
-			grainOverlay={0.03}
-			grainSize={0.5}
-			fit="cover"
-		/>
+		{#if webglSupported}
+			<HalftoneCMYK
+				width="100%"
+				height="100%"
+				image={heroImage}
+				class="size-full"
+				colorBack={isDark ? '#080b14' : '#fbfaf4'}
+				colorC="#2563eb"
+				colorM="#8b5cf6"
+				colorY="#f4b740"
+				colorK="#1e3a8a"
+				type="ink"
+				size={0.12}
+				gridNoise={0.08}
+				softness={0.65}
+				contrast={1.05}
+				gainC={0.18}
+				gainM={0.08}
+				gainY={0.1}
+				gainK={0.04}
+				grainMixer={0.02}
+				grainOverlay={0.03}
+				grainSize={0.5}
+				fit="cover"
+			/>
+		{:else}
+			<img src={heroImage} alt="" class="size-full object-cover" />
+		{/if}
 	</div>
 	<div
 		class="pointer-events-none absolute inset-0 z-[1] bg-linear-to-b from-background/65 via-background/25 to-background/15"

--- a/src/routes/(marketing)/changelog/+page.svelte
+++ b/src/routes/(marketing)/changelog/+page.svelte
@@ -5,6 +5,46 @@
 
 	const changelog = [
 		{
+			version: '1.7.4',
+			date: 'August 17, 2026',
+			sections: [
+				{
+					title: 'Reliability',
+					items: [
+						'Added a static hero background for browsers without WebGL2 support',
+						'Fixed the automated user-name cleanup step used during database migrations'
+					]
+				}
+			]
+		},
+		{
+			version: '1.7.3',
+			date: 'August 17, 2026',
+			sections: [
+				{
+					title: 'Improvements',
+					items: [
+						'Unified theme preferences so System mode follows your device color scheme everywhere',
+						'Improved the Materials empty state with clearer guidance for owners and group members',
+						'Limited account names to 64 characters and cleaned up existing overlength names'
+					]
+				}
+			]
+		},
+		{
+			version: '1.7.2',
+			date: 'August 17, 2026',
+			sections: [
+				{
+					title: 'Improvements',
+					items: [
+						'Refreshed the homepage hero with new light and dark visual treatments',
+						'Improved the landing page layout, typography, and responsive presentation'
+					]
+				}
+			]
+		},
+		{
 			version: '1.7.1',
 			date: 'August 16, 2026',
 			sections: [

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -184,9 +184,9 @@
 			},
 			"browserRequirements": "Requires JavaScript",
 			"operatingSystem": "Any",
-			"softwareVersion": "1.6.9",
+			"softwareVersion": "1.7.4",
 			"datePublished": "2025-12-12",
-			"dateModified": "2026-08-14",
+			"dateModified": "2026-08-17",
 			"inLanguage": "en-US",
 			"isAccessibleForFree": true,
 			"educationalUse": [

--- a/src/routes/app/settings/+page.svelte
+++ b/src/routes/app/settings/+page.svelte
@@ -19,7 +19,7 @@
 	import { resetPostHogUser } from '$lib/client/posthog-analytics';
 	import { onboardingSubjectGroups } from '$lib/onboarding-subjects.js';
 	import { SUPER_GRADIENT_BUTTON_CLASS } from '$lib/super/ui';
-	const APP_VERSION = '1.6.9';
+	const APP_VERSION = '1.7.4';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import { userPrefersMode } from 'mode-watcher';


### PR DESCRIPTION
## Summary

- Add a WebGL2 capability check and static hero-image fallback for browsers that cannot run the Paper Shaders landing hero.
- Fix automated user-name trimming in CI by loading the SvelteKit environment preload.
- Update the changelog for versions 1.7.2, 1.7.3, and 1.7.4.
- Update package, UI, and application version references to 1.7.4.

## Validation

- `bun run lint`
- `bun run check`
- `bun run test:unit` - 429 tests passed
- `bun run build`